### PR TITLE
Fixed a bug that caused messy display of rooms images

### DIFF
--- a/administrator/components/com_chpanel/helpers/data.php
+++ b/administrator/components/com_chpanel/helpers/data.php
@@ -225,7 +225,7 @@ class CHPanelHelperData
 					$params->tags = isset($params->tags) ? array_keys((array) $params->tags) : array();
 					$params->rooms = isset($params->rooms) ? array_keys((array) $params->rooms) : array();
 
-					if (($type == 'hotel' && $params->tags) || ($type = 'room' && in_array($item->id, $params->rooms)))
+					if (($type == 'hotel' && $params->tags) || ($type == 'room' && in_array($item->id, $params->rooms)))
 					{
 
 						$path_image = JUri::root() . 'images/chpanel/images/' . $image->id;


### PR DESCRIPTION
A single " = " was used in the test that determines what photos are assigned to a room, causing it to give a false positive if $params->tags is null. It also causes images of multiple rooms to get mixed.